### PR TITLE
feat: Implementar Repositorios en Memoria para Etapa 2

### DIFF
--- a/src/main/java/com/biblioteca/sistemagestion/repositorios/LibroRepositoryImpl.java
+++ b/src/main/java/com/biblioteca/sistemagestion/repositorios/LibroRepositoryImpl.java
@@ -1,0 +1,63 @@
+package com.biblioteca.sistemagestion.repositorios;
+
+import com.biblioteca.sistemagestion.modelo.Libro;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+
+@Repository
+public class LibroRepositoryImpl implements LibroRepository {
+
+    private final Map<Long, Libro> libros = new HashMap<>();
+
+    private final AtomicLong sequenceGenerator = new AtomicLong(1);
+
+    @Override
+    public Libro save(Libro libro) {
+        Objects.requireNonNull(libro, "El libro no puede ser nulo.");
+
+        if (libro.getId() == null) {
+            libro.setId(sequenceGenerator.getAndIncrement());
+        }
+
+        libros.put(libro.getId(), libro);
+        return libro;
+    }
+
+    @Override
+    public Optional<Libro> findById(Long id) {
+        Objects.requireNonNull(id, "El ID no puede ser nulo.");
+        return Optional.ofNullable(libros.get(id));
+    }
+
+    @Override
+    public Optional<Libro> findByIsbn(String isbn) {
+        Objects.requireNonNull(isbn, "El ISBN no puede ser nulo.");
+        return libros.values().stream()
+                .filter(libro -> isbn.equals(libro.getIsbn()))
+                .findFirst();
+    }
+
+    @Override
+    public List<Libro> findAll() {
+        return new ArrayList<>(libros.values());
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        Objects.requireNonNull(id, "El ID no puede ser nulo para eliminar.");
+        libros.remove(id);
+    }
+
+    @Override
+    public boolean existsById(Long id) {
+        Objects.requireNonNull(id, "El ID no puede ser nulo para verificar existencia.");
+        return libros.containsKey(id);
+    }
+}

--- a/src/main/java/com/biblioteca/sistemagestion/repositorios/PrestamoRepositoryImpl.java
+++ b/src/main/java/com/biblioteca/sistemagestion/repositorios/PrestamoRepositoryImpl.java
@@ -1,0 +1,73 @@
+package com.biblioteca.sistemagestion.repositorios;
+
+import com.biblioteca.sistemagestion.modelo.Prestamo;
+import com.biblioteca.sistemagestion.modelo.Libro;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+
+@Repository
+public class PrestamoRepositoryImpl implements PrestamoRepository {
+
+    private final Map<Long, Prestamo> prestamos = new HashMap<>();
+    private final AtomicLong sequenceGenerator = new AtomicLong(1);
+
+    @Override
+    public Prestamo save(Prestamo prestamo) {
+        Objects.requireNonNull(prestamo, "El préstamo no puede ser nulo.");
+        if (prestamo.getId() == null) {
+            prestamo.setId(sequenceGenerator.getAndIncrement());
+        }
+        prestamos.put(prestamo.getId(), prestamo);
+        return prestamo;
+    }
+
+    @Override
+    public Optional<Prestamo> findById(Long id) {
+        Objects.requireNonNull(id, "El ID del préstamo no puede ser nulo.");
+        return Optional.ofNullable(prestamos.get(id));
+    }
+
+    @Override
+    public List<Prestamo> findAll() {
+        return new ArrayList<>(prestamos.values());
+    }
+
+    @Override
+    public List<Prestamo> findByUsuarioId(Long usuarioId) {
+        Objects.requireNonNull(usuarioId, "El ID de usuario no puede ser nulo.");
+        return prestamos.values().stream()
+                .filter(prestamo -> prestamo.getUsuario() != null && usuarioId.equals(prestamo.getUsuario().getId()))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<Prestamo> findByLibroId(Long libroId) {
+        Objects.requireNonNull(libroId, "El ID del libro no puede ser nulo.");
+        return prestamos.values().stream()
+                .filter(prestamo -> prestamo.getLibro() != null && libroId.equals(prestamo.getLibro().getId()))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public Optional<Prestamo> findActiveByLibroId(Long libroId) {
+        Objects.requireNonNull(libroId, "El ID del libro no puede ser nulo.");
+        return prestamos.values().stream()
+                .filter(prestamo -> prestamo.getLibro() != null && libroId.equals(prestamo.getLibro().getId()))
+                .findFirst(); // Devuelve el primero (o único) préstamo para ese libro ID
+    }
+
+
+    @Override
+    public void deleteById(Long id) {
+        Objects.requireNonNull(id, "El ID del préstamo no puede ser nulo para eliminar.");
+        prestamos.remove(id);
+    }
+}

--- a/src/main/java/com/biblioteca/sistemagestion/repositorios/UsuarioRepositoryImpl.java
+++ b/src/main/java/com/biblioteca/sistemagestion/repositorios/UsuarioRepositoryImpl.java
@@ -1,0 +1,60 @@
+package com.biblioteca.sistemagestion.repositorios;
+
+import com.biblioteca.sistemagestion.modelo.Usuario;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+
+@Repository
+public class UsuarioRepositoryImpl implements UsuarioRepository {
+
+    private final Map<Long, Usuario> usuarios = new HashMap<>();
+    private final AtomicLong sequenceGenerator = new AtomicLong(1);
+
+    @Override
+    public Usuario save(Usuario usuario) {
+        Objects.requireNonNull(usuario, "El usuario no puede ser nulo.");
+        if (usuario.getId() == null) {
+            usuario.setId(sequenceGenerator.getAndIncrement());
+        }
+        usuarios.put(usuario.getId(), usuario);
+        return usuario;
+    }
+
+    @Override
+    public Optional<Usuario> findById(Long id) {
+        Objects.requireNonNull(id, "El ID no puede ser nulo.");
+        return Optional.ofNullable(usuarios.get(id));
+    }
+
+    @Override
+    public Optional<Usuario> findByEmail(String email) {
+        Objects.requireNonNull(email, "El email no puede ser nulo.");
+        return usuarios.values().stream()
+                .filter(usuario -> usuario.getEmail() != null && email.equalsIgnoreCase(usuario.getEmail()))
+                .findFirst();
+    }
+
+    @Override
+    public List<Usuario> findAll() {
+        return new ArrayList<>(usuarios.values());
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        Objects.requireNonNull(id, "El ID no puede ser nulo para eliminar.");
+        usuarios.remove(id);
+    }
+
+    @Override
+    public boolean existsById(Long id) {
+        Objects.requireNonNull(id, "El ID no puede ser nulo para verificar existencia.");
+        return usuarios.containsKey(id);
+    }
+}


### PR DESCRIPTION
Closes #7 

Este Pull Request introduce las implementaciones concretas en memoria para las interfaces de Repositorio definidas previamente, como parte de la Etapa 2. Estas clases simulan la persistencia de datos utilizando colecciones Java y gestionan la generación de IDs para nuevas entidades.

**Cambios Realizados:**

Se crearon las siguientes clases de implementación en el paquete `com.biblioteca.sistemagestion.repositorios`, todas anotadas con `@Repository`:

1.  **`LibroRepositoryImpl.java`:**
    * Implementa la interfaz `LibroRepository`.
    * Utiliza un `HashMap<Long, Libro>` interno para almacenar los libros.
    * Emplea un `AtomicLong` para la generación secuencial y segura de IDs para nuevos libros.
    * Implementa todos los métodos definidos en `LibroRepository` (save, findById, findByIsbn, findAll, deleteById, existsById).

2.  **`UsuarioRepositoryImpl.java`:**
    * Implementa la interfaz `UsuarioRepository`.
    * Utiliza un `HashMap<Long, Usuario>` interno para almacenar los usuarios.
    * Emplea un `AtomicLong` para la generación de IDs.
    * Implementa todos los métodos definidos en `UsuarioRepository` (save, findById, findByEmail, findAll, deleteById, existsById).

3.  **`PrestamoRepositoryImpl.java`:**
    * Implementa la interfaz `PrestamoRepository`.
    * Utiliza un `HashMap<Long, Prestamo>` interno para almacenar los préstamos.
    * Emplea un `AtomicLong` para la generación de IDs.
    * Implementa todos los métodos definidos en `PrestamoRepository` (save, findById, findAll, findByUsuarioId, findByLibroId, findActiveByLibroId, deleteById).

Estas implementaciones proporcionan la capa de acceso a datos simulada que será utilizada por los servicios en las siguientes tareas.