### PR TITLE
feat: Implementar LibroController con endpoints CRUD para Etapa 3

### DIFF
--- a/src/main/java/com/biblioteca/sistemagestion/controladores/LibroController.java
+++ b/src/main/java/com/biblioteca/sistemagestion/controladores/LibroController.java
@@ -15,6 +15,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import java.net.URI;
 import com.biblioteca.sistemagestion.excepciones.RecursoDuplicadoException;
+import org.springframework.web.bind.annotation.PutMapping;
+import com.biblioteca.sistemagestion.excepciones.LibroNoEncontradoException;
 
 import java.util.Objects;
 
@@ -65,6 +67,19 @@ public class LibroController {
         } catch (IllegalArgumentException e) {
             throw e;
         }
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Libro> actualizarLibro(@PathVariable Long id, @RequestBody Libro libroDetails) {
+        try {
+            Libro libroActualizado = libroService.actualizarLibro(id, libroDetails);
+            return ResponseEntity.ok(libroActualizado);
+        } catch (LibroNoEncontradoException e) {
+            throw e;
+        } catch (RecursoDuplicadoException e) {
+            throw e; // Relanzamos
+        }
+
     }
 
 }

--- a/src/main/java/com/biblioteca/sistemagestion/controladores/LibroController.java
+++ b/src/main/java/com/biblioteca/sistemagestion/controladores/LibroController.java
@@ -9,6 +9,12 @@ import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import java.util.Optional;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+import java.net.URI;
+import com.biblioteca.sistemagestion.excepciones.RecursoDuplicadoException;
 
 import java.util.Objects;
 
@@ -39,6 +45,26 @@ public class LibroController {
             return ResponseEntity.notFound().build();
         }
 
+    }
+
+    @PostMapping
+    public ResponseEntity<?> crearLibro(@RequestBody Libro libro) {
+        try {
+            Libro libroCreado = libroService.crearLibro(libro);
+
+            URI location = ServletUriComponentsBuilder
+                    .fromCurrentRequest()
+                    .path("/{id}")
+                    .buildAndExpand(libroCreado.getId())
+                    .toUri();
+
+            return ResponseEntity.created(location).body(libroCreado);
+
+        } catch (RecursoDuplicadoException e) {
+            throw e;
+        } catch (IllegalArgumentException e) {
+            throw e;
+        }
     }
 
 }

--- a/src/main/java/com/biblioteca/sistemagestion/controladores/LibroController.java
+++ b/src/main/java/com/biblioteca/sistemagestion/controladores/LibroController.java
@@ -6,6 +6,9 @@ import org.springframework.web.bind.annotation.RestController;
 import com.biblioteca.sistemagestion.modelo.Libro;
 import org.springframework.web.bind.annotation.GetMapping;
 import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import java.util.Optional;
 
 import java.util.Objects;
 
@@ -24,6 +27,18 @@ public class LibroController {
     public List<Libro> obtenerTodos() {
 
         return libroService.obtenerTodosLosLibros();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Libro> obtenerLibroPorId(@PathVariable Long id) {
+        Optional<Libro> libroOptional = libroService.obtenerLibroPorId(id);
+
+        if (libroOptional.isPresent()) {
+            return ResponseEntity.ok(libroOptional.get());
+        } else {
+            return ResponseEntity.notFound().build();
+        }
+
     }
 
 }

--- a/src/main/java/com/biblioteca/sistemagestion/controladores/LibroController.java
+++ b/src/main/java/com/biblioteca/sistemagestion/controladores/LibroController.java
@@ -3,6 +3,9 @@ package com.biblioteca.sistemagestion.controladores;
 import com.biblioteca.sistemagestion.servicios.LibroService;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import com.biblioteca.sistemagestion.modelo.Libro;
+import org.springframework.web.bind.annotation.GetMapping;
+import java.util.List;
 
 import java.util.Objects;
 
@@ -15,6 +18,12 @@ public class LibroController {
 
     public LibroController(LibroService libroService) {
         this.libroService = Objects.requireNonNull(libroService, "LibroService no puede ser nulo.");
+    }
+
+    @GetMapping
+    public List<Libro> obtenerTodos() {
+
+        return libroService.obtenerTodosLosLibros();
     }
 
 }

--- a/src/main/java/com/biblioteca/sistemagestion/controladores/LibroController.java
+++ b/src/main/java/com/biblioteca/sistemagestion/controladores/LibroController.java
@@ -1,0 +1,20 @@
+package com.biblioteca.sistemagestion.controladores;
+
+import com.biblioteca.sistemagestion.servicios.LibroService;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Objects;
+
+
+@RestController
+@RequestMapping("/api/libros")
+public class LibroController {
+
+    private final LibroService libroService;
+
+    public LibroController(LibroService libroService) {
+        this.libroService = Objects.requireNonNull(libroService, "LibroService no puede ser nulo.");
+    }
+
+}

--- a/src/main/java/com/biblioteca/sistemagestion/controladores/LibroController.java
+++ b/src/main/java/com/biblioteca/sistemagestion/controladores/LibroController.java
@@ -17,6 +17,7 @@ import java.net.URI;
 import com.biblioteca.sistemagestion.excepciones.RecursoDuplicadoException;
 import org.springframework.web.bind.annotation.PutMapping;
 import com.biblioteca.sistemagestion.excepciones.LibroNoEncontradoException;
+import org.springframework.web.bind.annotation.DeleteMapping;
 
 import java.util.Objects;
 
@@ -77,9 +78,19 @@ public class LibroController {
         } catch (LibroNoEncontradoException e) {
             throw e;
         } catch (RecursoDuplicadoException e) {
-            throw e; // Relanzamos
+            throw e;
         }
-
     }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> eliminarLibro(@PathVariable Long id) {
+        try {
+            libroService.eliminarLibro(id);
+            return ResponseEntity.noContent().build();
+        } catch (LibroNoEncontradoException e) {
+            throw e;
+        }
+    }
+
 
 }

--- a/src/main/java/com/biblioteca/sistemagestion/servicios/LibroService.java
+++ b/src/main/java/com/biblioteca/sistemagestion/servicios/LibroService.java
@@ -2,13 +2,14 @@ package com.biblioteca.sistemagestion.servicios;
 
 import com.biblioteca.sistemagestion.modelo.Libro;
 import com.biblioteca.sistemagestion.excepciones.LibroNoEncontradoException;
+import com.biblioteca.sistemagestion.excepciones.RecursoDuplicadoException;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface LibroService {
 
-    Libro crearLibro(Libro libro);
+    Libro crearLibro(Libro libro) throws RecursoDuplicadoException;
 
     Optional<Libro> obtenerLibroPorId(Long id);
 


### PR DESCRIPTION
Closes #16 

Este Pull Request introduce la implementación completa de `LibroController`, que expone una API REST para las operaciones CRUD sobre la entidad `Libro`, como parte de la Etapa 3.

**Cambios Realizados y Funcionalidades Implementadas:**

1.  **Creación de `LibroController.java`:**
    * Ubicado en el paquete `com.biblioteca.sistemagestion.controladores`.
    * Anotado con `@RestController` y `@RequestMapping("/api/libros")` para definir la ruta base.
    * Inyecta la dependencia `LibroService` vía constructor para delegar la lógica de negocio.

2.  **Endpoints Implementados:**
    * **`GET /api/libros`**:
        * Obtiene y devuelve una lista de todos los libros (`List<Libro>`).
        * Responde con HTTP 200 OK.
    * **`GET /api/libros/{id}`**:
        * Obtiene y devuelve un libro específico por su `id` (`@PathVariable`).
        * Devuelve `ResponseEntity.ok(libro)` (HTTP 200) si se encuentra.
        * Devuelve `ResponseEntity.notFound().build()` (HTTP 404) si el libro no existe (basado en el `Optional` del servicio).
    * **`POST /api/libros`**:
        * Crea un nuevo libro a partir de un objeto `Libro` recibido en el `@RequestBody`.
        * Llama a `libroService.crearLibro()`.
        * Devuelve `ResponseEntity.created(location).body(libroCreado)` (HTTP 201) con la URI del nuevo recurso en la cabecera `Location`.
        * Actualmente relanza excepciones como `RecursoDuplicadoException` o `IllegalArgumentException` que serían manejadas por un futuro `@ControllerAdvice`.
    * **`PUT /api/libros/{id}`**:
        * Actualiza un libro existente identificado por `id` (`@PathVariable`) con los datos de `Libro` del `@RequestBody`.
        * Llama a `libroService.actualizarLibro()`.
        * Devuelve `ResponseEntity.ok(libroActualizado)` (HTTP 200).
        * Relanza `LibroNoEncontradoException` (para futuro manejo global y respuesta 404).
    * **`DELETE /api/libros/{id}`**:
        * Elimina un libro por su `id` (`@PathVariable`).
        * Llama a `libroService.eliminarLibro()`.
        * Devuelve `ResponseEntity.noContent().build()` (HTTP 204).
        * Relanza `LibroNoEncontradoException` (para futuro manejo global y respuesta 404).

Este controlador establece la interfaz API para la gestión de libros y se prepara para un manejo de excepciones más centralizado con `@ControllerAdvice` (Issue #H).