### PR TITLE
feat: Implementar UsuarioController con endpoints CRUD para Etapa 3

### DIFF
--- a/src/main/java/com/biblioteca/sistemagestion/controladores/UsuarioController.java
+++ b/src/main/java/com/biblioteca/sistemagestion/controladores/UsuarioController.java
@@ -1,0 +1,18 @@
+package com.biblioteca.sistemagestion.controladores;
+
+import com.biblioteca.sistemagestion.servicios.UsuarioService;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import java.util.Objects;
+
+@RestController
+@RequestMapping("/api/usuarios")
+public class UsuarioController {
+
+    private final UsuarioService usuarioService;
+
+    public UsuarioController(UsuarioService usuarioService) {
+        this.usuarioService = Objects.requireNonNull(usuarioService, "UsuarioService no puede ser nulo.");
+    }
+
+}

--- a/src/main/java/com/biblioteca/sistemagestion/controladores/UsuarioController.java
+++ b/src/main/java/com/biblioteca/sistemagestion/controladores/UsuarioController.java
@@ -16,6 +16,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import java.net.URI;
 import com.biblioteca.sistemagestion.excepciones.RecursoDuplicadoException;
+import org.springframework.web.bind.annotation.PutMapping;
+import com.biblioteca.sistemagestion.excepciones.UsuarioNoEncontradoException;
 
 @RestController
 @RequestMapping("/api/usuarios")
@@ -51,6 +53,20 @@ public class UsuarioController {
                     .buildAndExpand(usuarioCreado.getId())
                     .toUri();
             return ResponseEntity.created(location).body(usuarioCreado);
+        } catch (RecursoDuplicadoException e) {
+            throw e;
+        } catch (IllegalArgumentException e) {
+            throw e;
+        }
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Usuario> actualizarUsuario(@PathVariable Long id, @RequestBody Usuario usuarioDetails) {
+        try {
+            Usuario usuarioActualizado = usuarioService.actualizarUsuario(id, usuarioDetails);
+            return ResponseEntity.ok(usuarioActualizado); // HTTP 200 OK
+        } catch (UsuarioNoEncontradoException e) {
+            throw e;
         } catch (RecursoDuplicadoException e) {
             throw e;
         } catch (IllegalArgumentException e) {

--- a/src/main/java/com/biblioteca/sistemagestion/controladores/UsuarioController.java
+++ b/src/main/java/com/biblioteca/sistemagestion/controladores/UsuarioController.java
@@ -4,6 +4,9 @@ import com.biblioteca.sistemagestion.servicios.UsuarioService;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import java.util.Objects;
+import com.biblioteca.sistemagestion.modelo.Usuario;
+import org.springframework.web.bind.annotation.GetMapping;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/usuarios")
@@ -13,6 +16,11 @@ public class UsuarioController {
 
     public UsuarioController(UsuarioService usuarioService) {
         this.usuarioService = Objects.requireNonNull(usuarioService, "UsuarioService no puede ser nulo.");
+    }
+
+    @GetMapping
+    public List<Usuario> obtenerTodosLosUsuarios() {
+        return usuarioService.obtenerTodosLosUsuarios();
     }
 
 }

--- a/src/main/java/com/biblioteca/sistemagestion/controladores/UsuarioController.java
+++ b/src/main/java/com/biblioteca/sistemagestion/controladores/UsuarioController.java
@@ -10,6 +10,12 @@ import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import java.util.Optional;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+import java.net.URI;
+import com.biblioteca.sistemagestion.excepciones.RecursoDuplicadoException;
 
 @RestController
 @RequestMapping("/api/usuarios")
@@ -33,6 +39,23 @@ public class UsuarioController {
         return usuarioOptional
                 .map(usuarioEncontrado -> ResponseEntity.ok(usuarioEncontrado))
                 .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    public ResponseEntity<?> crearUsuario(@RequestBody Usuario usuario) {
+        try {
+            Usuario usuarioCreado = usuarioService.crearUsuario(usuario);
+            URI location = ServletUriComponentsBuilder
+                    .fromCurrentRequest()
+                    .path("/{id}")
+                    .buildAndExpand(usuarioCreado.getId())
+                    .toUri();
+            return ResponseEntity.created(location).body(usuarioCreado);
+        } catch (RecursoDuplicadoException e) {
+            throw e;
+        } catch (IllegalArgumentException e) {
+            throw e;
+        }
     }
 
 }

--- a/src/main/java/com/biblioteca/sistemagestion/controladores/UsuarioController.java
+++ b/src/main/java/com/biblioteca/sistemagestion/controladores/UsuarioController.java
@@ -7,6 +7,9 @@ import java.util.Objects;
 import com.biblioteca.sistemagestion.modelo.Usuario;
 import org.springframework.web.bind.annotation.GetMapping;
 import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import java.util.Optional;
 
 @RestController
 @RequestMapping("/api/usuarios")
@@ -21,6 +24,15 @@ public class UsuarioController {
     @GetMapping
     public List<Usuario> obtenerTodosLosUsuarios() {
         return usuarioService.obtenerTodosLosUsuarios();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Usuario> obtenerUsuarioPorId(@PathVariable Long id) {
+        Optional<Usuario> usuarioOptional = usuarioService.obtenerUsuarioPorId(id);
+
+        return usuarioOptional
+                .map(usuarioEncontrado -> ResponseEntity.ok(usuarioEncontrado))
+                .orElseGet(() -> ResponseEntity.notFound().build());
     }
 
 }

--- a/src/main/java/com/biblioteca/sistemagestion/controladores/UsuarioController.java
+++ b/src/main/java/com/biblioteca/sistemagestion/controladores/UsuarioController.java
@@ -18,6 +18,7 @@ import java.net.URI;
 import com.biblioteca.sistemagestion.excepciones.RecursoDuplicadoException;
 import org.springframework.web.bind.annotation.PutMapping;
 import com.biblioteca.sistemagestion.excepciones.UsuarioNoEncontradoException;
+import org.springframework.web.bind.annotation.DeleteMapping;
 
 @RestController
 @RequestMapping("/api/usuarios")
@@ -70,6 +71,16 @@ public class UsuarioController {
         } catch (RecursoDuplicadoException e) {
             throw e;
         } catch (IllegalArgumentException e) {
+            throw e;
+        }
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> eliminarUsuario(@PathVariable Long id) {
+        try {
+            usuarioService.eliminarUsuario(id);
+            return ResponseEntity.noContent().build();
+        } catch (UsuarioNoEncontradoException e) {
             throw e;
         }
     }

--- a/src/main/java/com/biblioteca/sistemagestion/servicios/UsuarioService.java
+++ b/src/main/java/com/biblioteca/sistemagestion/servicios/UsuarioService.java
@@ -2,13 +2,14 @@ package com.biblioteca.sistemagestion.servicios;
 
 import com.biblioteca.sistemagestion.modelo.Usuario;
 import com.biblioteca.sistemagestion.excepciones.UsuarioNoEncontradoException;
+import com.biblioteca.sistemagestion.excepciones.RecursoDuplicadoException;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface UsuarioService {
 
-    Usuario crearUsuario(Usuario usuario);
+    Usuario crearUsuario(Usuario usuario) throws RecursoDuplicadoException;
 
     Optional<Usuario> obtenerUsuarioPorId(Long id);
 

--- a/src/main/java/com/biblioteca/sistemagestion/servicios/UsuarioService.java
+++ b/src/main/java/com/biblioteca/sistemagestion/servicios/UsuarioService.java
@@ -17,7 +17,7 @@ public interface UsuarioService {
 
     List<Usuario> obtenerTodosLosUsuarios();
 
-    Usuario actualizarUsuario(Long id, Usuario usuarioDetails) throws UsuarioNoEncontradoException;
+    Usuario actualizarUsuario(Long id, Usuario usuarioDetails) throws UsuarioNoEncontradoException, RecursoDuplicadoException;
 
     void eliminarUsuario(Long id) throws UsuarioNoEncontradoException;
 }


### PR DESCRIPTION
Closes #15 

Este Pull Request introduce la implementación completa de `UsuarioController`, que expone una API REST para las operaciones CRUD sobre la entidad `Usuario`, como parte de la Etapa 3.

**Cambios Realizados y Funcionalidades Implementadas:**

1.  **Creación de `UsuarioController.java`:**
    * Ubicado en el paquete `com.biblioteca.sistemagestion.controladores`.
    * Anotado con `@RestController` y `@RequestMapping("/api/usuarios")` para definir la ruta base.
    * Inyecta la dependencia `UsuarioService` vía constructor para delegar la lógica de negocio.

2.  **Endpoints Implementados:**
    * **`GET /api/usuarios`**:
        * Obtiene y devuelve una lista de todos los usuarios (`List<Usuario>`).
        * Responde con HTTP 200 OK.
    * **`GET /api/usuarios/{id}`**:
        * Obtiene y devuelve un usuario específico por su `id` (`@PathVariable`).
        * Devuelve `ResponseEntity.ok(usuario)` (HTTP 200) si se encuentra.
        * Devuelve `ResponseEntity.notFound().build()` (HTTP 404) si el usuario no existe (basado en el `Optional` del servicio).
    * **`POST /api/usuarios`**:
        * Crea un nuevo usuario a partir de un objeto `Usuario` recibido en el `@RequestBody`.
        * Llama a `usuarioService.crearUsuario()`.
        * Devuelve `ResponseEntity.created(location).body(usuarioCreado)` (HTTP 201) con la URI del nuevo recurso en la cabecera `Location`.
        * Actualmente relanza excepciones como `RecursoDuplicadoException` (por email) o `IllegalArgumentException` que serían manejadas por un futuro `@ControllerAdvice`.
    * **`PUT /api/usuarios/{id}`**:
        * Actualiza un usuario existente identificado por `id` (`@PathVariable`) con los datos de `Usuario` del `@RequestBody`.
        * Llama a `usuarioService.actualizarUsuario()`.
        * Devuelve `ResponseEntity.ok(usuarioActualizado)` (HTTP 200).
        * Relanza `UsuarioNoEncontradoException` y `RecursoDuplicadoException` (para futuro manejo global y respuesta 404/409).
    * **`DELETE /api/usuarios/{id}`**:
        * Elimina un usuario por su `id` (`@PathVariable`).
        * Llama a `usuarioService.eliminarUsuario()`.
        * Devuelve `ResponseEntity.noContent().build()` (HTTP 204).
        * Relanza `UsuarioNoEncontradoException` (para futuro manejo global y respuesta 404).

Este controlador establece la interfaz API para la gestión de usuarios y delega la lógica de negocio al `UsuarioService`. El manejo detallado de excepciones para convertirlas a respuestas HTTP específicas se abordará con un `@ControllerAdvice` .