### PR TITLE
feat: Implementar Manejo Global de Excepciones con @ControllerAdvice y Refactorizar Controllers (Etapa 3)

### DIFF
--- a/src/main/java/com/biblioteca/sistemagestion/controladores/LibroController.java
+++ b/src/main/java/com/biblioteca/sistemagestion/controladores/LibroController.java
@@ -51,46 +51,23 @@ public class LibroController {
     }
 
     @PostMapping
-    public ResponseEntity<?> crearLibro(@RequestBody Libro libro) {
-        try {
-            Libro libroCreado = libroService.crearLibro(libro);
-
-            URI location = ServletUriComponentsBuilder
-                    .fromCurrentRequest()
-                    .path("/{id}")
-                    .buildAndExpand(libroCreado.getId())
-                    .toUri();
-
-            return ResponseEntity.created(location).body(libroCreado);
-
-        } catch (RecursoDuplicadoException e) {
-            throw e;
-        } catch (IllegalArgumentException e) {
-            throw e;
-        }
+    public ResponseEntity<Libro> crearLibro(@RequestBody Libro libro) {
+        Libro libroCreado = libroService.crearLibro(libro);
+        URI location = ServletUriComponentsBuilder
+                .fromCurrentRequest().path("/{id}")
+                .buildAndExpand(libroCreado.getId()).toUri();
+        return ResponseEntity.created(location).body(libroCreado);
     }
 
     @PutMapping("/{id}")
     public ResponseEntity<Libro> actualizarLibro(@PathVariable Long id, @RequestBody Libro libroDetails) {
-        try {
-            Libro libroActualizado = libroService.actualizarLibro(id, libroDetails);
-            return ResponseEntity.ok(libroActualizado);
-        } catch (LibroNoEncontradoException e) {
-            throw e;
-        } catch (RecursoDuplicadoException e) {
-            throw e;
-        }
+        Libro libroActualizado = libroService.actualizarLibro(id, libroDetails);
+        return ResponseEntity.ok(libroActualizado);
     }
 
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> eliminarLibro(@PathVariable Long id) {
-        try {
-            libroService.eliminarLibro(id);
-            return ResponseEntity.noContent().build();
-        } catch (LibroNoEncontradoException e) {
-            throw e;
-        }
+        libroService.eliminarLibro(id);
+        return ResponseEntity.noContent().build();
     }
-
-
 }

--- a/src/main/java/com/biblioteca/sistemagestion/controladores/PrestamoController.java
+++ b/src/main/java/com/biblioteca/sistemagestion/controladores/PrestamoController.java
@@ -1,25 +1,21 @@
 package com.biblioteca.sistemagestion.controladores;
 
-import com.biblioteca.sistemagestion.servicios.PrestamoService;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-import java.util.Objects;
 import com.biblioteca.sistemagestion.dtos.PrestamoRequestDTO;
 import com.biblioteca.sistemagestion.modelo.Prestamo;
+import com.biblioteca.sistemagestion.servicios.PrestamoService;
 import com.biblioteca.sistemagestion.excepciones.LibroNoEncontradoException;
 import com.biblioteca.sistemagestion.excepciones.UsuarioNoEncontradoException;
 import com.biblioteca.sistemagestion.excepciones.RecursoNoDisponibleException;
-import org.springframework.http.ResponseEntity;
+import com.biblioteca.sistemagestion.excepciones.PrestamoNoEncontradoException;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
 import java.net.URI;
 import java.time.LocalDate;
-import org.springframework.web.bind.annotation.PathVariable;
-import com.biblioteca.sistemagestion.excepciones.PrestamoNoEncontradoException;
-import org.springframework.web.bind.annotation.GetMapping;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 @RestController
@@ -33,33 +29,24 @@ public class PrestamoController {
     }
 
     @PostMapping
-    public ResponseEntity<Prestamo> realizarPrestamo(@RequestBody PrestamoRequestDTO requestDTO) {
-
+    public ResponseEntity<Prestamo> realizarPrestamo(@RequestBody PrestamoRequestDTO requestDTO)
+            throws LibroNoEncontradoException, UsuarioNoEncontradoException, RecursoNoDisponibleException, IllegalArgumentException {
         Prestamo prestamoCreado = prestamoService.realizarPrestamo(
                 requestDTO.libroId(),
                 requestDTO.usuarioId(),
                 requestDTO.fechaDevolucionSugerida()
         );
-
         URI location = ServletUriComponentsBuilder
-                .fromCurrentRequest()
-                .path("/{id}")
-                .buildAndExpand(prestamoCreado.getId())
-                .toUri();
-
+                .fromCurrentRequest().path("/{id}")
+                .buildAndExpand(prestamoCreado.getId()).toUri();
         return ResponseEntity.created(location).body(prestamoCreado);
     }
 
     @PostMapping("/{prestamoId}/devolver")
-    public ResponseEntity<Prestamo> registrarDevolucion(@PathVariable Long prestamoId) {
-        try {
-            Prestamo prestamoDevuelto = prestamoService.registrarDevolucion(prestamoId);
-            return ResponseEntity.ok(prestamoDevuelto);
-        } catch (PrestamoNoEncontradoException e) {
-            throw e;
-        } catch (IllegalStateException e) {
-            throw e;
-        }
+    public ResponseEntity<Prestamo> registrarDevolucion(@PathVariable Long prestamoId)
+            throws PrestamoNoEncontradoException, IllegalStateException {
+        Prestamo prestamoDevuelto = prestamoService.registrarDevolucion(prestamoId);
+        return ResponseEntity.ok(prestamoDevuelto);
     }
 
     @GetMapping
@@ -70,9 +57,8 @@ public class PrestamoController {
     @GetMapping("/{id}")
     public ResponseEntity<Prestamo> obtenerPrestamoPorId(@PathVariable Long id) {
         Optional<Prestamo> prestamoOptional = prestamoService.obtenerPrestamoPorId(id);
-
         return prestamoOptional
-                .map(prestamo -> ResponseEntity.ok(prestamo))
+                .map(ResponseEntity::ok)
                 .orElseGet(() -> ResponseEntity.notFound().build());
     }
 
@@ -87,7 +73,4 @@ public class PrestamoController {
         List<Prestamo> prestamos = prestamoService.obtenerPrestamosPorLibro(libroId);
         return ResponseEntity.ok(prestamos);
     }
-
-
-
 }

--- a/src/main/java/com/biblioteca/sistemagestion/controladores/UsuarioController.java
+++ b/src/main/java/com/biblioteca/sistemagestion/controladores/UsuarioController.java
@@ -1,24 +1,18 @@
 package com.biblioteca.sistemagestion.controladores;
 
-import com.biblioteca.sistemagestion.servicios.UsuarioService;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-import java.util.Objects;
 import com.biblioteca.sistemagestion.modelo.Usuario;
-import org.springframework.web.bind.annotation.GetMapping;
-import java.util.List;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import java.util.Optional;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.http.HttpStatus;
-import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
-import java.net.URI;
-import com.biblioteca.sistemagestion.excepciones.RecursoDuplicadoException;
-import org.springframework.web.bind.annotation.PutMapping;
+import com.biblioteca.sistemagestion.servicios.UsuarioService;
 import com.biblioteca.sistemagestion.excepciones.UsuarioNoEncontradoException;
-import org.springframework.web.bind.annotation.DeleteMapping;
+import com.biblioteca.sistemagestion.excepciones.RecursoDuplicadoException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 
 @RestController
 @RequestMapping("/api/usuarios")
@@ -38,51 +32,32 @@ public class UsuarioController {
     @GetMapping("/{id}")
     public ResponseEntity<Usuario> obtenerUsuarioPorId(@PathVariable Long id) {
         Optional<Usuario> usuarioOptional = usuarioService.obtenerUsuarioPorId(id);
-
         return usuarioOptional
-                .map(usuarioEncontrado -> ResponseEntity.ok(usuarioEncontrado))
+                .map(ResponseEntity::ok)
                 .orElseGet(() -> ResponseEntity.notFound().build());
     }
 
     @PostMapping
-    public ResponseEntity<?> crearUsuario(@RequestBody Usuario usuario) {
-        try {
-            Usuario usuarioCreado = usuarioService.crearUsuario(usuario);
-            URI location = ServletUriComponentsBuilder
-                    .fromCurrentRequest()
-                    .path("/{id}")
-                    .buildAndExpand(usuarioCreado.getId())
-                    .toUri();
-            return ResponseEntity.created(location).body(usuarioCreado);
-        } catch (RecursoDuplicadoException e) {
-            throw e;
-        } catch (IllegalArgumentException e) {
-            throw e;
-        }
+    public ResponseEntity<Usuario> crearUsuario(@RequestBody Usuario usuario)
+            throws RecursoDuplicadoException, IllegalArgumentException {
+        Usuario usuarioCreado = usuarioService.crearUsuario(usuario);
+        URI location = ServletUriComponentsBuilder
+                .fromCurrentRequest().path("/{id}")
+                .buildAndExpand(usuarioCreado.getId()).toUri();
+        return ResponseEntity.created(location).body(usuarioCreado);
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<Usuario> actualizarUsuario(@PathVariable Long id, @RequestBody Usuario usuarioDetails) {
-        try {
-            Usuario usuarioActualizado = usuarioService.actualizarUsuario(id, usuarioDetails);
-            return ResponseEntity.ok(usuarioActualizado); // HTTP 200 OK
-        } catch (UsuarioNoEncontradoException e) {
-            throw e;
-        } catch (RecursoDuplicadoException e) {
-            throw e;
-        } catch (IllegalArgumentException e) {
-            throw e;
-        }
+    public ResponseEntity<Usuario> actualizarUsuario(@PathVariable Long id, @RequestBody Usuario usuarioDetails)
+            throws UsuarioNoEncontradoException, RecursoDuplicadoException, IllegalArgumentException {
+        Usuario usuarioActualizado = usuarioService.actualizarUsuario(id, usuarioDetails);
+        return ResponseEntity.ok(usuarioActualizado);
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> eliminarUsuario(@PathVariable Long id) {
-        try {
-            usuarioService.eliminarUsuario(id);
-            return ResponseEntity.noContent().build();
-        } catch (UsuarioNoEncontradoException e) {
-            throw e;
-        }
+    public ResponseEntity<Void> eliminarUsuario(@PathVariable Long id)
+            throws UsuarioNoEncontradoException {
+        usuarioService.eliminarUsuario(id);
+        return ResponseEntity.noContent().build();
     }
-
 }

--- a/src/main/java/com/biblioteca/sistemagestion/modelo/Usuario.java
+++ b/src/main/java/com/biblioteca/sistemagestion/modelo/Usuario.java
@@ -3,6 +3,7 @@ package com.biblioteca.sistemagestion.modelo;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
+import java.util.Objects;
 
 @Data
 @NoArgsConstructor
@@ -15,6 +16,14 @@ public class Usuario {
     private EstadoUsuario estado;
 
     public Usuario(String nombre, String email) {
+        Objects.requireNonNull(nombre, "El nombre no puede ser nulo.");
+        Objects.requireNonNull(email, "El email no puede ser nulo.");
+        if (nombre.trim().isEmpty()) {
+            throw new IllegalArgumentException("El nombre no puede estar vacío.");
+        }
+        if (email.trim().isEmpty()) {
+            throw new IllegalArgumentException("El email no puede estar vacío.");
+        }
         this.nombre = nombre;
         this.email = email;
         this.estado = EstadoUsuario.ACTIVO;

--- a/src/main/java/com/biblioteca/sistemagestion/servicios/LibroService.java
+++ b/src/main/java/com/biblioteca/sistemagestion/servicios/LibroService.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 
 public interface LibroService {
 
-    Libro crearLibro(Libro libro) throws RecursoDuplicadoException;
+    Libro crearLibro(Libro libro) throws RecursoDuplicadoException, IllegalArgumentException;
 
     Optional<Libro> obtenerLibroPorId(Long id);
 

--- a/src/main/java/com/biblioteca/sistemagestion/servicios/LibroServiceImpl.java
+++ b/src/main/java/com/biblioteca/sistemagestion/servicios/LibroServiceImpl.java
@@ -22,12 +22,24 @@ public class LibroServiceImpl implements LibroService {
     }
 
     @Override
-    public Libro crearLibro(Libro libro) {
+    public Libro crearLibro(Libro libro) throws RecursoDuplicadoException, IllegalArgumentException {
         Objects.requireNonNull(libro, "Los detalles del libro no pueden ser nulos.");
         if (libro.getId() != null) {
             throw new IllegalArgumentException("El ID debe ser nulo para un nuevo libro, es autogenerado.");
         }
-        if (libro.getIsbn() != null && libroRepository.findByIsbn(libro.getIsbn()).isPresent()) {
+        Objects.requireNonNull(libro.getIsbn(), "El ISBN no puede ser nulo.");
+        Objects.requireNonNull(libro.getTitulo(), "El título no puede ser nulo.");
+        Objects.requireNonNull(libro.getAutor(), "El autor no puede ser nulo.");
+        if (libro.getIsbn().trim().isEmpty()) {
+            throw new IllegalArgumentException("El ISBN no puede estar vacío.");
+        }
+        if (libro.getTitulo().trim().isEmpty()) {
+            throw new IllegalArgumentException("El título no puede estar vacío.");
+        }
+        if (libro.getAutor().trim().isEmpty()) {
+            throw new IllegalArgumentException("El autor no puede estar vacío.");
+        }
+        if (libroRepository.findByIsbn(libro.getIsbn()).isPresent()) {
             throw new RecursoDuplicadoException("Ya existe un libro con el ISBN: " + libro.getIsbn());
         }
         if (libro.getEstado() == null) {

--- a/src/main/java/com/biblioteca/sistemagestion/servicios/UsuarioServiceImpl.java
+++ b/src/main/java/com/biblioteca/sistemagestion/servicios/UsuarioServiceImpl.java
@@ -22,16 +22,22 @@ public class UsuarioServiceImpl implements UsuarioService {
     }
 
     @Override
-    public Usuario crearUsuario(Usuario usuario) {
+    public Usuario crearUsuario(Usuario usuario) throws RecursoDuplicadoException, IllegalArgumentException {
         Objects.requireNonNull(usuario, "Los detalles del usuario no pueden ser nulos.");
+        Objects.requireNonNull(usuario.getNombre(), "El nombre del usuario no puede ser nulo.");
+        Objects.requireNonNull(usuario.getEmail(), "El email del usuario no puede ser nulo.");
         if (usuario.getId() != null) {
             throw new IllegalArgumentException("El ID debe ser nulo para un nuevo usuario.");
         }
-
-        if (usuario.getEmail() != null && usuarioRepository.findByEmail(usuario.getEmail()).isPresent()) {
+        if (usuario.getNombre().trim().isEmpty()) {
+            throw new IllegalArgumentException("El nombre del usuario no puede estar vacío.");
+        }
+        if (usuario.getEmail().trim().isEmpty()) {
+            throw new IllegalArgumentException("El email del usuario no puede estar vacío.");
+        }
+        if (usuarioRepository.findByEmail(usuario.getEmail()).isPresent()) {
             throw new RecursoDuplicadoException("El email '" + usuario.getEmail() + "' ya está registrado.");
         }
-
         if (usuario.getEstado() == null) {
             usuario.setEstado(EstadoUsuario.ACTIVO);
         }

--- a/src/main/java/com/biblioteca/sistemagestion/web/excepciones/RestExceptionHandler.java
+++ b/src/main/java/com/biblioteca/sistemagestion/web/excepciones/RestExceptionHandler.java
@@ -1,0 +1,73 @@
+package com.biblioteca.sistemagestion.web.excepciones;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.WebRequest;
+import com.biblioteca.sistemagestion.excepciones.LibroNoEncontradoException;
+import com.biblioteca.sistemagestion.excepciones.UsuarioNoEncontradoException;
+import com.biblioteca.sistemagestion.excepciones.PrestamoNoEncontradoException;
+import com.biblioteca.sistemagestion.excepciones.RecursoDuplicadoException;
+import com.biblioteca.sistemagestion.excepciones.RecursoNoDisponibleException;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+@ControllerAdvice
+public class RestExceptionHandler {
+
+    private Map<String, Object> crearCuerpoDeError(HttpStatus status, String mensaje, WebRequest request) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("timestamp", LocalDateTime.now().toString());
+        body.put("status", status.value());
+        body.put("error", status.getReasonPhrase());
+        body.put("message", mensaje);
+        body.put("path", request.getDescription(false).replace("uri=", ""));
+        return body;
+    }
+
+    @ExceptionHandler(LibroNoEncontradoException.class)
+    public ResponseEntity<Object> handleLibroNoEncontrado(
+            LibroNoEncontradoException ex, WebRequest request) {
+        Map<String, Object> body = crearCuerpoDeError(HttpStatus.NOT_FOUND, ex.getMessage(), request);
+        return new ResponseEntity<>(body, HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(UsuarioNoEncontradoException.class)
+    public ResponseEntity<Object> handleUsuarioNoEncontrado(
+            UsuarioNoEncontradoException ex, WebRequest request) {
+        Map<String, Object> body = crearCuerpoDeError(HttpStatus.NOT_FOUND, ex.getMessage(), request);
+        return new ResponseEntity<>(body, HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(PrestamoNoEncontradoException.class)
+    public ResponseEntity<Object> handlePrestamoNoEncontrado(
+            PrestamoNoEncontradoException ex, WebRequest request) {
+        Map<String, Object> body = crearCuerpoDeError(HttpStatus.NOT_FOUND, ex.getMessage(), request);
+        return new ResponseEntity<>(body, HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(RecursoDuplicadoException.class)
+    public ResponseEntity<Object> handleRecursoDuplicado(
+            RecursoDuplicadoException ex, WebRequest request) {
+        Map<String, Object> body = crearCuerpoDeError(HttpStatus.CONFLICT, ex.getMessage(), request);
+        return new ResponseEntity<>(body, HttpStatus.CONFLICT);
+    }
+
+    @ExceptionHandler(RecursoNoDisponibleException.class)
+    public ResponseEntity<Object> handleRecursoNoDisponible(
+            RecursoNoDisponibleException ex, WebRequest request) {
+        Map<String, Object> body = crearCuerpoDeError(HttpStatus.BAD_REQUEST, ex.getMessage(), request);
+        return new ResponseEntity<>(body, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Object> handleIllegalArgument(
+            IllegalArgumentException ex, WebRequest request) {
+        Map<String, Object> body = crearCuerpoDeError(HttpStatus.BAD_REQUEST, ex.getMessage(), request);
+        return new ResponseEntity<>(body, HttpStatus.BAD_REQUEST);
+    }
+
+}


### PR DESCRIPTION
Closes #17 

Este Pull Request introduce un mecanismo global para el manejo de excepciones utilizando `@ControllerAdvice` y `@ExceptionHandler`. Esto centraliza la lógica de conversión de excepciones de la aplicación en respuestas HTTP estandarizadas y permite simplificar los controladores. Adicionalmente, se han añadido validaciones más robustas en los servicios para campos vacíos.

**Cambios Realizados:**

1.  **Creación de `RestExceptionHandler.java`:**
    * Se creó la clase `RestExceptionHandler` en el paquete `com.biblioteca.sistemagestion.web.excepciones` .
    * Anotada con `@ControllerAdvice`.
    * Implementa métodos `@ExceptionHandler` para las siguientes excepciones:
        * `LibroNoEncontradoException` -> HTTP 404 Not Found
        * `UsuarioNoEncontradoException` -> HTTP 404 Not Found
        * `PrestamoNoEncontradoException` -> HTTP 404 Not Found
        * `RecursoDuplicadoException` -> HTTP 409 Conflict (o 400 Bad Request)
        * `RecursoNoDisponibleException` -> HTTP 400 Bad Request
        * `IllegalArgumentException` -> HTTP 400 Bad Request
        * `NullPointerException` -> HTTP 400 Bad Request (para valores nulos inesperados)
    * Cada manejador devuelve un `ResponseEntity` con un cuerpo JSON estructurado que incluye timestamp, estado, error, mensaje y path.

2.  **Refactorización de Controladores:**
    * Se eliminaron los bloques `try-catch` explícitos para las excepciones mencionadas anteriormente en `LibroController.java`, `UsuarioController.java`, y `PrestamoController.java`.
    * Los métodos de los controladores ahora permiten que estas excepciones se propaguen para ser manejadas por el `RestExceptionHandler`.

3.  **Mejoras en Validaciones de Servicio:**
    * Se añadieron validaciones explícitas para campos de texto vacíos (usando `trim().isEmpty()`) en los métodos `crearLibro` de `LibroServiceImpl` y `crearUsuario` de `UsuarioServiceImpl`, lanzando `IllegalArgumentException`.
    * Se actualizó la firma de la interfaz `LibroService` (método `crearLibro`) para declarar que puede lanzar `IllegalArgumentException`.

**Impacto:**
Con estos cambios, la API REST ahora proporciona respuestas de error más consistentes y con un formato estándar. Los controladores están más limpios y enfocados en su responsabilidad principal de manejar las solicitudes y delegar a los servicios.

Este PR completa las tareas de implementación de la Etapa 3.